### PR TITLE
Fix serialExist()

### DIFF
--- a/smsUPS.py
+++ b/smsUPS.py
@@ -1287,19 +1287,15 @@ def serialExist(serialPort, imprime=True):
     ret = False
     if osEnv['os.name'] == 'posix':
         import os
-        res = os.system("ls ".join(serialPort))
-        if res==0:
-            ret = True
-        else:
-            ret = False
+        ret = os.path.exists(serialPort)
     else:
         dl.printC(Color.B_Magenta, 'Error - Not linux system')
         exit()
     if imprime:
         if ret:  
-            dl.printC(Color.B_Blue, ''.join(serialPort).join(' exist'))
+            dl.printC(Color.B_Blue, ''.join(serialPort)+' exist')
         else:
-            dl.printC(Color.B_Red, ''.join(serialPort).join(' not exist'))
+            dl.printC(Color.B_Red, ''.join(serialPort)+' not exist')
     return ret
 
 def abre_serial():


### PR DESCRIPTION
Olá!

Esta função estava tendo um comportamento inadequado ao concatenar as strings no Python 3.11.4, intercalando os joins dentro da nova string. Também tive problemas com o teste de os.path - que foi resolvido pelo os.path.exists completamente.

Resolvi usar uma concatenação mais simples nesse PR.

Está tudo bem para você fazer o merge dessas correções?